### PR TITLE
Fix too large error of image <= 5MB

### DIFF
--- a/Sources/Extensions/NSImage++.swift
+++ b/Sources/Extensions/NSImage++.swift
@@ -52,10 +52,4 @@ extension NSImage {
         return composedImage
     }
 
-    func toData(from fileType: NSBitmapImageRep.FileType, quality: CGFloat = 1) -> Data? {
-        let dict: Dictionary<NSBitmapImageRep.PropertyKey, Any> = [NSBitmapImageRep.PropertyKey.compressionFactor: NSNumber(value: Float(quality))]
-        let imageRep: NSBitmapImageRep = NSBitmapImageRep(data: self.tiffRepresentation!)!
-        return imageRep.representation(using: fileType, properties: dict)
-    }
-
 }

--- a/Sources/TwitterClient.swift
+++ b/Sources/TwitterClient.swift
@@ -177,13 +177,13 @@ class TwitterClient {
                                      userInfo: ["oldUserID" : account.userID])
     }
 
-    func tweet(account: TwitterClient.Account, text: String, with artwork: NSImage? = nil, success: Swifter.SuccessHandler? = nil, failure: Swifter.FailureHandler? = nil) {
+    func tweet(account: TwitterClient.Account, text: String, with artwork: Data? = nil, success: Swifter.SuccessHandler? = nil, failure: Swifter.FailureHandler? = nil) {
         if artwork == nil {
             account.swifter.postTweet(status: text, success: success, failure: failure)
             return
         }
-        let image = artwork?.toData(from: .jpeg)
-        account.swifter.postTweet(status: text, media: image!, success: success, failure: failure)
+
+        account.swifter.postTweet(status: text, media: artwork!, success: success, failure: failure)
     }
 
     private func updateCurrentAccount() {

--- a/Sources/iTunesPlayerInfo.swift
+++ b/Sources/iTunesPlayerInfo.swift
@@ -24,8 +24,8 @@ class iTunesPlayerInfo {
 
         let artworks: [iTunesArtwork]
 
-        var artwork: NSImage? {
-            return self.artworks.isEmpty ? nil : self.artworks[0].data
+        var artwork: Data? {
+            return self.artworks.isEmpty ? nil : self.artworks[0].rawData
         }
     }
 


### PR DESCRIPTION
Fixed #9

`NSImage` を取得して `Data` に変換していたがそれのせいで画像サイズが大きくなっていた可能性がある。rawDataを利用して投稿する形に変更する