### PR TITLE
Changeable credentials api key

### DIFF
--- a/NowPlayingTweet.xcodeproj/project.pbxproj
+++ b/NowPlayingTweet.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		3DEF425F22527526008E977A /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEF425E22527526008E977A /* Provider.swift */; };
 		3DF4A6DC20277722007A7B29 /* NSEvent++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4A6DB20277722007A7B29 /* NSEvent++.swift */; };
 		3DF4A6DE20277873007A7B29 /* NSStoryboard++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF4A6DD20277873007A7B29 /* NSStoryboard++.swift */; };
+		3DFCA42A23A8F0300042135E /* Provider++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFCA42923A8F0300042135E /* Provider++.swift */; };
 		3DFF864F2041E1F6004FDD88 /* GlobalKeyEquivalents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF864E2041E1F5004FDD88 /* GlobalKeyEquivalents.swift */; };
 		3DFF865120430789004FDD88 /* KeyEquivalentsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF865020430789004FDD88 /* KeyEquivalentsDelegate.swift */; };
 		3DFF866320474754004FDD88 /* KeyEquivalentsPaneController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF866220474753004FDD88 /* KeyEquivalentsPaneController.swift */; };
@@ -147,6 +148,7 @@
 		3DEF425E22527526008E977A /* Provider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		3DF4A6DB20277722007A7B29 /* NSEvent++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSEvent++.swift"; sourceTree = "<group>"; };
 		3DF4A6DD20277873007A7B29 /* NSStoryboard++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSStoryboard++.swift"; sourceTree = "<group>"; };
+		3DFCA42923A8F0300042135E /* Provider++.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Provider++.swift"; sourceTree = "<group>"; };
 		3DFF864E2041E1F5004FDD88 /* GlobalKeyEquivalents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobalKeyEquivalents.swift; sourceTree = "<group>"; };
 		3DFF865020430789004FDD88 /* KeyEquivalentsDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyEquivalentsDelegate.swift; sourceTree = "<group>"; };
 		3DFF8658204718E7004FDD88 /* Magnet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Magnet.framework; path = Carthage/Build/Mac/Magnet.framework; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 		3D5A4B34218B492500775D4E /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3DFCA42923A8F0300042135E /* Provider++.swift */,
 				3DD88B272024974C000F7818 /* Notification++.swift */,
 				3DCEE8172027014800D87CE5 /* NSButton++.swift */,
 				3D9D294423A2E3030031505C /* NSGridView++.swift */,
@@ -480,6 +483,7 @@
 				3D9D294F23A50C3D0031505C /* ProviderAccounts.swift in Sources */,
 				3DF4A6DC20277722007A7B29 /* NSEvent++.swift in Sources */,
 				3D9D295823A648F60031505C /* SocialError.swift in Sources */,
+				3DFCA42A23A8F0300042135E /* Provider++.swift in Sources */,
 				3DAA09AE202C47EE00C6F449 /* Accounts.swift in Sources */,
 				3D5520D22022322200AAF108 /* AppDelegate.swift in Sources */,
 				3DFF864F2041E1F6004FDD88 /* GlobalKeyEquivalents.swift in Sources */,

--- a/Sources/Accounts.swift
+++ b/Sources/Accounts.swift
@@ -122,11 +122,12 @@ class Accounts {
     }
 
     func login(provider: Provider) {
-        guard let client = provider.client else {
+        guard let client = provider.client
+            , let (key, secret) = provider.clientKey else {
             return
         }
 
-        client.authorize(callbackURLScheme: "nowplayingtweet", handler: { credentials in
+        client.authorize(key: key, secret: secret, callbackURLScheme: "nowplayingtweet", handler: { credentials in
             client.init(credentials)?.verify(handler: { account in
                 let provider = type(of: account).provider
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -239,9 +239,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, KeyEquivalentsDelegate, NSMe
         let postText = self.createPostText(from: currentTrack)
 
         if self.userDefaults.bool(forKey: "PostWithImage") {
-            Accounts.shared.client(for: account).post(text: postText, image: currentTrack.artwork, failure: failure)
+            Accounts.shared.client(for: account)?.post(text: postText, image: currentTrack.artwork, failure: failure)
         } else {
-            Accounts.shared.client(for: account).post(text: postText, failure: failure)
+            Accounts.shared.client(for: account)?.post(text: postText, failure: failure)
         }
     }
 

--- a/Sources/Extensions/Provider++.swift
+++ b/Sources/Extensions/Provider++.swift
@@ -1,0 +1,55 @@
+/**
+ *  Provider++.swift
+ *  NowPlayingTweet
+ *
+ *  © 2019 kPherox.
+**/
+
+import Cocoa
+
+extension Provider {
+
+    var accounts: ProviderAccounts.Type? {
+        switch self {
+        case .Twitter:
+            return TwitterAccounts.self
+        }
+    }
+
+    var client: Client.Type? {
+        switch self {
+        case .Twitter:
+            return TwitterClient.self
+        default:
+            return nil
+        }
+    }
+
+    var credentials: Credentials.Type? {
+        switch self {
+        case .Twitter:
+            return TwitterCredentials.self
+        default:
+            return nil
+        }
+    }
+
+    var logo: NSImage? {
+        switch self {
+        case .Twitter:
+            return NSImage(named: "Twitter Logo")
+        default:
+            return nil
+        }
+    }
+
+    var brand: NSImage? {
+        switch self {
+        case .Twitter:
+            return nil
+        default:
+            return nil
+        }
+    }
+
+}

--- a/Sources/Extensions/Provider++.swift
+++ b/Sources/Extensions/Provider++.swift
@@ -52,4 +52,15 @@ extension Provider {
         }
     }
 
+    var clientKey: (String, String)? {
+        switch self {
+        case .Twitter:
+            let apiKey: String = "uH6FFqSPBi1ZG80I6taO5xt24"
+            let apiSecret: String = "0gIbzrGYW6CU2W3DoehwuLQz8SXojr8v5z5I2DaBPjm9kHbt16"
+            return (apiKey, apiSecret)
+        default:
+            return nil
+        }
+    }
+
 }

--- a/Sources/Social/Client.swift
+++ b/Sources/Social/Client.swift
@@ -12,7 +12,7 @@ protocol Client {
     typealias Success = () -> Void
     typealias Failure = (Error) -> Void
 
-    static func authorize(callbackURLScheme: String?, handler: ((Credentials) -> Void)?, failure: Failure?)
+    static func authorize(key: String, secret: String, callbackURLScheme: String?, handler: ((Credentials) -> Void)?, failure: Failure?)
 
     var credentials: Credentials { get }
 
@@ -28,8 +28,8 @@ protocol Client {
 
 extension Client {
 
-    static func authorize(callbackURLScheme urlScheme: String? = nil, handler: ((Credentials) -> Void)? = nil, failure: Failure? = nil) {
-        return Self.authorize(callbackURLScheme: urlScheme, handler: handler, failure: failure)
+    static func authorize(key: String, secret: String, callbackURLScheme urlScheme: String? = nil, handler: ((Credentials) -> Void)? = nil, failure: Failure? = nil) {
+        return Self.authorize(key: key, secret: secret, callbackURLScheme: urlScheme, handler: handler, failure: failure)
     }
 
     func revoke(handler: Success? = nil, failure: Failure? = nil) {

--- a/Sources/Social/Credentials.swift
+++ b/Sources/Social/Credentials.swift
@@ -11,4 +11,7 @@ protocol Credentials {
 
     static var oauthVersion: OAuth { get }
 
+    var apiKey: String { get }
+    var apiSecret: String { get }
+
 }

--- a/Sources/Social/OAuth1.swift
+++ b/Sources/Social/OAuth1.swift
@@ -9,9 +9,6 @@ import Foundation
 
 protocol OAuth1 {
 
-    static var apiKey: String { get }
-    static var apiSecret: String { get }
-
     var oauthToken: String { get }
     var oauthSecret: String { get }
 

--- a/Sources/Social/Provider.swift
+++ b/Sources/Social/Provider.swift
@@ -5,44 +5,10 @@
  *  © 2019 kPherox.
 **/
 
-import Cocoa
+import Foundation
 
 enum Provider: String, CaseIterable {
 
     case Twitter
-
-}
-
-extension Provider {
-
-    var accounts: ProviderAccounts.Type {
-        switch self {
-            case .Twitter: return TwitterAccounts.self
-        }
-    }
-
-    var client: Client.Type {
-        switch self {
-            case .Twitter: return TwitterClient.self
-        }
-    }
-
-    var credentials: Credentials.Type {
-        switch self {
-            case .Twitter: return TwitterCredentials.self
-        }
-    }
-
-    var logo: NSImage? {
-        switch self {
-            case .Twitter: return NSImage(named: "Twitter Logo")
-        }
-    }
-
-    var brand: NSImage? {
-        switch self {
-            case .Twitter: return nil
-        }
-    }
 
 }

--- a/Sources/Social/Twitter/TwitterCredentials.swift
+++ b/Sources/Social/Twitter/TwitterCredentials.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct TwitterCredentials: Credentials, Codable,  OAuth1 {
 
-    static let apiKey: String = "uH6FFqSPBi1ZG80I6taO5xt24"
-    static let apiSecret: String = "0gIbzrGYW6CU2W3DoehwuLQz8SXojr8v5z5I2DaBPjm9kHbt16"
+    let apiKey: String
+    let apiSecret: String
 
-    var oauthToken: String
-    var oauthSecret: String
+    let oauthToken: String
+    let oauthSecret: String
 
 }


### PR DESCRIPTION
#12 で誤った実装をしていたので修正する。今はしなくても将来的に `Social` をフレームワークにする時にめんどくさくなるし、Mastodonみたいなクライアントのオープン登録があるOAuthだとハードコードできない